### PR TITLE
Update registry.json

### DIFF
--- a/CIP-0010/registry.json
+++ b/CIP-0010/registry.json
@@ -36,6 +36,10 @@
     "description": "Open Badges v2.0 compliant metadata"
   },
   {
+    "transaction_metadatum_label": 1888,
+    "description": "amphitheatre by the ape society"
+  },
+  {
     "transaction_metadatum_label": 1967,
     "description": "nut.link metadata oracles registry"
   },


### PR DESCRIPTION
Added transaction_metadatum_label 1888 to registry.json for the Amphitheatre by The APE Society compliant metadata.